### PR TITLE
Remove /api path prefix and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ script:
 after_success:
 - docker login -u $DOCKER_USER -p $DOCKER_PASS
 - BRANCH=${TRAVIS_BRANCH//[^[:alnum:]]/}
-- export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo ${BRANCH,,}; fi`
+- export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "$TRAVIS_TAG"; else echo ${BRANCH,,}; fi`
 - export IMAGE_NAME=joelgtsantos/cmsusers
 - docker tag $IMAGE_NAME:"latest" $IMAGE_NAME:$TAG
 - docker push $IMAGE_NAME
+- docker push $IMAGE_NAME:$TAG

--- a/pom.xml
+++ b/pom.xml
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.joelgtsantos</groupId>
 	<artifactId>cmsusers</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<organization>
 		<name>${project.groupId}</name>
 	</organization>
 
-	<name>USERS</name>
+	<name>cmsusers</name>
 	<description>project by Spring Boot</description>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>1.5.2.RELEASE</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<relativePath />
+		<!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
+		<jar.finalName>${project.name}</jar.finalName>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<tomcat.version>8.5.31</tomcat.version>
@@ -136,8 +138,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-		    <groupId>org.springframework.boot</groupId>
-		    <artifactId>spring-boot-starter-security</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
@@ -183,7 +185,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.3.1</version>
+			<version>1.3.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -199,7 +201,7 @@
 			<groupId>com.jossemargt</groupId>
 			<artifactId>cookie-twist</artifactId>
 			<version>0.4.0</version>
-		</dependency>		
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -217,17 +219,17 @@
 					<fork>false</fork>
 					<executable>C:\Program Files\Java\jdk1.8.0_111\bin\javac</executable>
 					<compilerArgument>-Xlint</compilerArgument>
-					<!-- <annotationProcessors> <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor> 
-						<annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor> 
+					<!-- <annotationProcessors> <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>
+						<annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
 						</annotationProcessors> -->
 				</configuration>
 			</plugin>
 			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-deploy-plugin</artifactId>
-			    <configuration>
-			        <skip>true</skip>
-			    </configuration>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -316,7 +318,7 @@
 			<plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.2.3</version>
+				<version>1.2.2</version>
 				<configuration>
 					<imageName>${docker.image.prefix}/${project.artifactId}</imageName>
 					<dockerDirectory>src/main/docker</dockerDirectory>
@@ -324,7 +326,7 @@
 						<resource>
 							<targetPath>/</targetPath>
 							<directory>${project.build.directory}</directory>
-							<include>${project.build.finalName}.jar</include>
+							<include>${project.name}.jar</include>
 						</resource>
 					</resources>
 				</configuration>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,3 +1,5 @@
-FROM java:8
-COPY cmsusers-1.0-SNAPSHOT.jar app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+FROM openjdk:11-jre
+
+COPY cmsusers.jar /
+
+CMD ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/cmsusers.jar"]

--- a/src/main/java/com/joelgtsantos/cmsusers/inte/CmsServicesInt.java
+++ b/src/main/java/com/joelgtsantos/cmsusers/inte/CmsServicesInt.java
@@ -21,9 +21,9 @@ import com.joelgtsantos.cmsusers.entity.User;
 import com.joelgtsantos.cmsusers.exception.ExceptionInternalError;
 
 @RestController
-@RequestMapping(value = "/api/v1/auth", produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
+@RequestMapping(value = "/v1/auth", produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
 public interface CmsServicesInt {
-	
+
 	/*
 	 * Login
 	 * */
@@ -31,22 +31,22 @@ public interface CmsServicesInt {
 	@RequestMapping(value = {"","/login"},method= RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<User> login(@RequestBody User user, HttpServletRequest request, HttpServletResponse response)
 			throws ExceptionInternalError;
-	
+
 	/*
 	 * Register and login with social accounts
 	 * */
 	@RequestMapping(value = "/register", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<User> socialRegister( 
+	public ResponseEntity<User> socialRegister(
 			Principal principal,
 			HttpServletRequest request,
-			HttpServletResponse response) 
+			HttpServletResponse response)
 	            		throws ExceptionInternalError;
-	
+
 	@RequestMapping(value = "/redirect", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ModelAndView redirect(
 			@RequestParam Map<String, String> queryParameters,
 			@RequestParam MultiValueMap<String, String> multiMap,
-			HttpServletResponse response) 
+			HttpServletResponse response)
 	            		throws ExceptionInternalError;
-	
+
 }

--- a/src/main/java/com/joelgtsantos/cmsusers/inte/UserExtraInformationInt.java
+++ b/src/main/java/com/joelgtsantos/cmsusers/inte/UserExtraInformationInt.java
@@ -18,9 +18,9 @@ import com.joelgtsantos.cmsusers.entity.UserExtraInformation;
 import com.joelgtsantos.cmsusers.exception.ExceptionInternalError;
 
 @RestController
-@RequestMapping(value = "/api/v1/users/extra", produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
+@RequestMapping(value = "/v1/users/extra", produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
 public interface UserExtraInformationInt {
-	
+
 	/**
 	 *
 	 * @param ID
@@ -30,12 +30,12 @@ public interface UserExtraInformationInt {
 	 * @throws ErrorInternoException
 	 */
 	@RequestMapping(value = {"",""},method= RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<UserExtraInformation> getUser(
-    		Principal principal,
-    		HttpServletRequest request, 
-    		HttpServletResponse response);
-	
-	
+	public ResponseEntity<UserExtraInformation> getUser(
+			Principal principal,
+			HttpServletRequest request,
+			HttpServletResponse response);
+
+
 	/**
 	 *
 	 * @param user
@@ -49,10 +49,10 @@ public interface UserExtraInformationInt {
 	ResponseEntity<UserExtraInformation> doCreate(
 			@RequestBody UserExtraInformation userextra,
 			Principal principal,
-			HttpServletRequest request, 
+			HttpServletRequest request,
 			HttpServletResponse response)
 			throws ExceptionInternalError;
-	 
+
 
 	/**
 	 *

--- a/src/main/java/com/joelgtsantos/cmsusers/inte/UserInt.java
+++ b/src/main/java/com/joelgtsantos/cmsusers/inte/UserInt.java
@@ -20,9 +20,9 @@ import com.joelgtsantos.cmsusers.entity.UserDTO;
 import com.joelgtsantos.cmsusers.exception.ExceptionInternalError;
 
 @RestController
-@RequestMapping(value = "/api/v1/users", produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
+@RequestMapping(value = "/v1/users", produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
 public interface UserInt {
-	
+
 	/**
 	 *
 	 * @param ID
@@ -33,8 +33,8 @@ public interface UserInt {
 	 */
 	@RequestMapping(value = {"","/"},method= RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody  Iterable<User> getUsers(HttpServletRequest request);
-	
-	
+
+
 	/**
 	 *
 	 * @param ID
@@ -46,7 +46,7 @@ public interface UserInt {
 	@RequestMapping(value = "/{id}" ,method= RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	public @ResponseBody User getUser(@PathVariable("id") long id,
 									 HttpServletRequest request);
-	
+
 	/**
 	 *
 	 * @param InfoUsersRequestDTO
@@ -57,9 +57,9 @@ public interface UserInt {
 	 */
 	@Transactional(readOnly = false)
 	@RequestMapping(value = { "", "/" }, method = RequestMethod.POST)
-	@ResponseBody  
-	public Set<UserDTO> getInfoUsers(@RequestBody InfoUsersRequestDTO infoUsersRequestDTO, 
-									  HttpServletRequest request, 
+	@ResponseBody
+	public Set<UserDTO> getInfoUsers(@RequestBody InfoUsersRequestDTO infoUsersRequestDTO,
+									  HttpServletRequest request,
 									  HttpServletResponse response)
 	throws ExceptionInternalError;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: cmsusers
   data:
     rest:
-      base-path: /api
+      base-path: /
   profiles.active: development
   jmx:
     enabled: false
@@ -17,8 +17,8 @@ contest-slug: new_contest1
 #---
 logging:
   level:
-    org.springframework.security: DEBUG
-  
+    org.springframework.security: INFO
+
 ---
 spring:
   profiles: development
@@ -29,7 +29,7 @@ spring:
       password: notsecure
       driver-class-name:  org.postgresql.Driver
       test-on-borrow: false
-      validation-query: SELECT 1  
+      validation-query: SELECT 1
       hibernate:
         #default_catalog: danos
         default_schema: public
@@ -51,7 +51,7 @@ spring:
     port: 5672
     username: joel
     password: joel1
-    
+
  # Spring Security configuration
 security:
   google:
@@ -67,7 +67,7 @@ security:
     resource:
       userInfoUri: https://www.googleapis.com/oauth2/v3/userinfo
       preferTokenInfo: false
-      
+
   github:
     client:
       clientId: 84321d8de8002c6f4e85


### PR DESCRIPTION
Since the api gateway is going to be exposed to the internet under
the /api location having the `api` keyword at the microservice
level becomes redundant.

Also I took the freedom to update upload-commons dependency (which
was flagged by github security scans) and the base image to
openjdk 11 (since this jvm is more "container" complaint regarding
resource management).