### PR TITLE
Use fat jar with final name on Docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.joelgtsantos</groupId>
 	<artifactId>cmsusers</artifactId>
-	<version>1.1-SNAPSHOT</version>
+	<version>1.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<organization>
@@ -24,7 +24,6 @@
 	</parent>
 
 	<properties>
-		<jar.finalName>${project.name}</jar.finalName>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<tomcat.version>8.5.31</tomcat.version>
@@ -205,6 +204,7 @@
 	</dependencies>
 
 	<build>
+		<finalName>${project.name}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The jar I mistakely added to the Docker image is the slim one,
meaning it does not holds any kind of dependencies within it.